### PR TITLE
Add debug viewhelper

### DIFF
--- a/Classes/ViewHelpers/DebugViewHelper.php
+++ b/Classes/ViewHelpers/DebugViewHelper.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace FriendsOfTYPO3\HeadlessDevTools\ViewHelpers;
+
+use TYPO3\CMS\Extbase\Utility\DebuggerUtility;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+
+class DebugViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\DebugViewHelper
+{
+    /**
+     * A wrapper for \TYPO3\CMS\Extbase\Utility\DebuggerUtility::var_dump().
+     *
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     *
+     * @return string
+     */
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    {
+        $dump = DebuggerUtility::var_dump($renderChildrenClosure(), $arguments['title'], $arguments['maxDepth'], (bool)$arguments['plainText'], (bool)$arguments['ansiColors'], (bool)$arguments['inline'], $arguments['blacklistedClassNames'], $arguments['blacklistedPropertyNames']);
+        echo $dump;
+        die();
+    }
+}

--- a/Classes/ViewHelpers/DebugViewHelper.php
+++ b/Classes/ViewHelpers/DebugViewHelper.php
@@ -3,10 +3,11 @@ declare(strict_types=1);
 
 namespace FriendsOfTYPO3\HeadlessDevTools\ViewHelpers;
 
-use TYPO3\CMS\Extbase\Utility\DebuggerUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3\CMS\Extbase\Utility\DebuggerUtility;
+use TYPO3\CMS\Fluid\ViewHelpers\DebugViewHelper as Fluid_DebugViewHelper;
 
-class DebugViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\DebugViewHelper
+class DebugViewHelper extends Fluid_DebugViewHelper
 {
     /**
      * A wrapper for \TYPO3\CMS\Extbase\Utility\DebuggerUtility::var_dump().
@@ -19,8 +20,7 @@ class DebugViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\DebugViewHelper
      */
     public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
     {
-        $dump = DebuggerUtility::var_dump($renderChildrenClosure(), $arguments['title'], $arguments['maxDepth'], (bool)$arguments['plainText'], (bool)$arguments['ansiColors'], (bool)$arguments['inline'], $arguments['blacklistedClassNames'], $arguments['blacklistedPropertyNames']);
-        echo $dump;
+        echo DebuggerUtility::var_dump($renderChildrenClosure(), $arguments['title'], $arguments['maxDepth'], (bool)$arguments['plainText'], (bool)$arguments['ansiColors'], (bool)$arguments['inline'], $arguments['blacklistedClassNames'], $arguments['blacklistedPropertyNames']);
         die();
     }
 }

--- a/README.md
+++ b/README.md
@@ -8,3 +8,19 @@ Install extension using composer
 ``composer require --dev friendsoftypo3/headless-dev-tools``
 
 **DO NOT USE IN PRODUCTION** always install as require-dev only
+
+## ViewHelpers
+
+### Debug ViewHelper
+
+Just like `f:debug` but dies afterwards, so its output is actually visible in the frontend response.
+
+```xml
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en"
+    xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
+    xmlns:hdt="http://typo3.org/ns/FriendsOfTYPO3/HeadlessDevTools/ViewHelpers"
+    data-namespace-typo3-fluid="true"
+>
+
+<hdt:debug title="_all">{_all}</hdt:debug>
+```

--- a/README.md
+++ b/README.md
@@ -16,11 +16,5 @@ Install extension using composer
 Just like `f:debug` but dies afterwards, so its output is actually visible in the frontend response.
 
 ```xml
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en"
-    xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
-    xmlns:hdt="http://typo3.org/ns/FriendsOfTYPO3/HeadlessDevTools/ViewHelpers"
-    data-namespace-typo3-fluid="true"
->
-
-<hdt:debug title="_all">{_all}</hdt:debug>
+<headlessDevTools:debug title="_all">{_all}</headlessDevTools:debug>
 ```

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -16,5 +16,7 @@ defined('TYPO3_MODE') || die();
         class_exists(\IchHabRecht\Filefill\Resource\RemoteResourceCollection::class)) {
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][\IchHabRecht\Filefill\Resource\RemoteResourceCollection::class]['className'] = \FriendsOfTYPO3\HeadlessDevTools\Xclass\RemoteResourceCollection::class;
     }
+
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['fluid']['namespaces']['headlessDevTools'] = ['FriendsOfTYPO3\\HeadlessDevTools\\ViewHelpers'];
 })('headless_dev_tools');
 


### PR DESCRIPTION
This viewhelper is exactly like f:debug() but dies after dumping the data, so it's actually visible in the frontend.

Replacing https://github.com/TYPO3-Headless/headless/pull/416