### PR TITLE
[TASK] Provide middleware to append admPanel

### DIFF
--- a/Classes/Middleware/AdminPanelRenderer.php
+++ b/Classes/Middleware/AdminPanelRenderer.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the "headless dev tools" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace FriendsOfTYPO3\HeadlessDevTools\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use TYPO3\CMS\Adminpanel\Controller\MainController;
+use TYPO3\CMS\Adminpanel\Utility\StateUtility;
+use TYPO3\CMS\Core\Http\Stream;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+
+/**
+ * Render the admin panel via PSR-15 middleware
+ *
+ * @internal
+ */
+class AdminPanelRenderer implements MiddlewareInterface
+{
+    /**
+     * Render the admin panel if activated
+     * @param ServerRequestInterface $request
+     * @param RequestHandlerInterface $handler
+     * @return ResponseInterface
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $response = $handler->handle($request);
+        if (
+            $GLOBALS['TSFE'] instanceof TypoScriptFrontendController
+            && StateUtility::isActivatedForUser()
+            && StateUtility::isActivatedInTypoScript()
+            && !StateUtility::isHiddenForUser()
+        ) {
+            $mainController = GeneralUtility::makeInstance(MainController::class);
+            $body = $response->getBody();
+            $body->rewind();
+            $contents = $response->getBody()->getContents();
+            $adminPanel = str_replace(["\n", "\r"], ['', ''], $mainController->render($request));
+            $adminPanel = json_encode($adminPanel);
+            $content = preg_replace(
+                '/}$/',
+                ',"adminPanel":' . $adminPanel . '}',
+                $contents
+            );
+            $body = new Stream('php://temp', 'rw');
+            $body->write($content);
+            $response = $response->withBody($body);
+        }
+        return $response;
+    }
+}

--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'frontend' => [
+        // Replace regular by headless middleware
+        'typo3/cms-adminpanel/renderer' => [
+            'target' => \FriendsOfTYPO3\HeadlessDevTools\Middleware\AdminPanelRenderer::class,
+        ],
+    ],
+];

--- a/README.md
+++ b/README.md
@@ -9,6 +9,16 @@ Install extension using composer
 
 **DO NOT USE IN PRODUCTION** always install as require-dev only
 
+## Admin Panel
+
+This extension provides a replacement for EXT:adminpanel's middleware to attach the adminpanel's HTML to the end of the rendered markup.
+
+```
+page.config.admPanel = 1
+```
+
+This renders the adminpanels HTML "as is" to the end of your JSON under the property key `admPanel`.
+
 ## ViewHelpers
 
 ### Debug ViewHelper


### PR DESCRIPTION
This adds the admin panel's HTML to the end of PAGE's JSON:

```json
{
   ...,
   "admPanel": "<!-- TYPO3 admin panel start --> ... <!-- TYPO3 admin panel end -->"
}
```

The idea is that the nuxtjs application can attach this HTML string "as is" right before the closing `</body>` tag.

Unfortunately there's some characters that cause problems and invalidate the resulting JSON ;-(

I can't find a way to correctly escape those characters. But I tracked it down to this symfony HtmlDumper here: https://github.com/TYPO3/typo3/blob/main/typo3/sysext/adminpanel/Classes/Modules/Debug/Events.php#L77